### PR TITLE
Change lookup request's origin to INCOMING_SMS

### DIFF
--- a/src/com/cyanogenmod/messaging/lookup/LookupProviderManager.java
+++ b/src/com/cyanogenmod/messaging/lookup/LookupProviderManager.java
@@ -249,7 +249,9 @@ public class LookupProviderManager implements Application.ActivityLifecycleCallb
         }
 
         if (mIsPhoneNumberLookupInitialized) {
-            LookupRequest request = new LookupRequest(phoneNumber, this);
+            // always map request origin to INCOMING_SMS whilst the CallerInfoApi is in flux
+            LookupRequest request = new LookupRequest(phoneNumber, this,
+                    LookupRequest.RequestOrigin.INCOMING_SMS);
             // [TODO][MSB]: Could pass up the return of this
             mLookupHandlerThread.fetchInfoForPhoneNumber(request);
         }


### PR DESCRIPTION
All of the requests are marked with the same origin code
while the CallerInfoApi is in flux. Eventually the two SMS
origin codes will be merged into one.

Change-Id: I59ff15a817a4db5291db52b478d27282fb3cfb18
Issue-Id: CYNGNOS-2279