### PR TITLE
msim: Fix broken assumptions around the meaning of subId/slotId/selfId

### DIFF
--- a/src/com/android/messaging/ui/conversation/ComposeMessageView.java
+++ b/src/com/android/messaging/ui/conversation/ComposeMessageView.java
@@ -339,21 +339,15 @@ public class ComposeMessageView extends LinearLayout
             @Override
             public void onClick(final View clickView) {
 
+                mConversationDataModel.getData().setOverrideSendingSubId(
+                                         ParticipantData.DEFAULT_SELF_SUB_ID);
                 if (isSMSPromptEnabled()) {
                     showSimSelector((Activity)mOriginalContext, new OnSimSelectedCallback() {
                         @Override
                         public void onSimSelected(int subId) {
-                            // subId is 1 based
-                            SubscriptionListEntry entry = getSubscriptionListEntry(subId-1);
-                            if (entry == null) {
-                                // shouldn't happen, but if it does, just send the message using the
-                                // old sim as opposed to crashing
-                                selectSim(entry);
-                            }
-                            sendMessageInternal(true /* checkMessageSize */);
+                            sendMessageWithSubId(subId);
                         }
                     });
-
                 } else {
                     sendMessageInternal(true /* checkMessageSize */);
                 }
@@ -718,8 +712,9 @@ public class ComposeMessageView extends LinearLayout
                 mBinding.getData().getSelfId(), false /* excludeDefault */);
     }
 
-    private SubscriptionListEntry getSubscriptionListEntry(int subId) {
-        return mConversationDataModel.getData().getSubscriptionEntry(subId);
+    private void sendMessageWithSubId(int subId) {
+         mConversationDataModel.getData().setOverrideSendingSubId(subId);
+         sendMessageInternal(true /* checkMessageSize */);
     }
 
     private boolean isDataLoadedForMessageSend() {


### PR DESCRIPTION
Make MSIM, "Always ask", and system choices actually apply unless
locally overriden in the thread

Ref CYNGNOS-2185
Change-Id: I01e03f5c1e312f53a65e9c39a3d283f652fbde7d