### PR TITLE
Added new feature MMS Validity Period, MMS Delivery,Read Report and MMS

### DIFF
--- a/res/values/cm_arrays.xml
+++ b/res/values/cm_arrays.xml
@@ -44,4 +44,29 @@
         <item>1440</item>
         <item>635040</item>
     </string-array>
+
+    <string-array name="save_time" translatable="false">
+        <item>@string/validity_period_maximum</item>
+        <item>@string/mms_validity_period_two_days</item>
+        <item>@string/mms_validity_period_one_week</item>
+    </string-array>
+
+    <string-array name="priority_send" translatable="false">
+        <item>@string/priority_low</item>
+        <item>@string/priority_normal</item>
+        <item>@string/priority_high</item>
+    </string-array>
+
+    <string-array name="save_time_values" translatable="false">
+        <item>-1</item>  <!-- maximum -->
+        <item>172800</item>   <!--2*24*60*60 -->
+        <item>604800</item>
+    </string-array>
+
+    <string-array name="priority_send_values" >
+        <item>128</item>    <!-- PRIORITY_LOW  -->
+        <item>129</item>    <!--PRIORITY_NORMAL -->
+        <item>130</item>    <!-- PRIORITY_HIGH  -->
+    </string-array>
+
 </resources>

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -24,15 +24,27 @@
     <string name="pref_unicode_stripping_all">Strip all unicode characters</string>
 
     <!-- Settings item description for SMS and MMS Validity period -->
-    <string name="pref_title_validity_period">Validity period</string>
-    <string name="pref_title_validity_period_slot1">Validity period for SIM 1</string>
-    <string name="pref_title_validity_period_slot2">Validity period for SIM 2</string>
+    <string name="validity_period_pref_title">Validity period</string>
+    <string name="validity_period_slot1_pref_title">Validity period for SIM 1</string>
+    <string name="validity_period_slot2_pref_title">Validity period for SIM 2</string>
     <string name="sms_validity_period_not_set">Not set</string>
     <string name="sms_validity_period_one_hour">1 hour</string>
     <string name="sms_validity_period_six_hours">6 hours</string>
     <string name="sms_validity_period_twelve_hours">12 hours</string>
     <string name="sms_validity_period_one_day">1 day</string>
+    <string name="mms_validity_period_two_days">2 days</string>
+    <string name="mms_validity_period_one_week">1 week</string>
     <string name="validity_period_maximum">Maximum</string>
+    <string name="pref_summary_mms_delivery_reports">Request a delivery report for each message you send</string>
+    <string name="pref_summary_mms_read_reports">Request a read report for each message you send</string>
+    <string name="delivery_reports_mms_pref_title">Delivery reports</string>
+    <string name="read_reports_mms_pref_title">Read reports</string>
+
+    <!-- Item Descriptions for MMS sending Priority -->
+    <string name="priority_pref_title">Send Priority</string>
+    <string name="priority_low">Low</string>
+    <string name="priority_normal">Normal</string>
+    <string name="priority_high">High</string>
 
     <!-- Swipe to delete conversation -->
     <string name="swipe_to_delete_conversation_pref_title">Swipe to delete</string>

--- a/res/values/constants.xml
+++ b/res/values/constants.xml
@@ -26,6 +26,12 @@
     <string name="pref_key_sms_validity_period" translatable="false">pref_key_sms_validity_period</string>
     <string name="pref_key_sms_validity_period_slot1" translatable="false">pref_key_sms_validity_period_slot1</string>
     <string name="pref_key_sms_validity_period_slot2" translatable="false">pref_key_sms_validity_period_slot2</string>
+    <string name="expiry_mms_pref_key" translatable="false">expiry_mms_pref_key</string>
+    <string name="expiry_slot1_mms_pref_key" translatable="false">expiry_slot1_mms_pref_key</string>
+    <string name="expiry_slot2_mms_pref_key" translatable="false">expiry_slot2_mms_pref_key</string>
+    <string name="delivery_reports_mms_pref_key" translatable="false">delivery_reports_mms_pref_key</string>
+    <string name="read_reports_mms_pref_key" translatable="false">read_reports_mms_pref_key</string>
+    <string name="priority_mms_pref_key" translatable="false">priority_mms_pref_key</string>
     <bool name="notifications_enabled_pref_default" translatable="false">true</bool>
     <string name="notification_sound_pref_key" translatable="false">notification_sound</string>
     <string name="notification_vibration_pref_key" translatable="false">notification_vibration</string>
@@ -43,6 +49,9 @@
 
     <!-- default sms validity period -->
     <string name="def_sms_validity_period_value" translatable="false">-1</string>
+
+    <!-- mms delivery reports enabled.default is true to on,false to off -->
+    <bool name="def_mms_delivery_reports">false</bool>
 
     <!-- Subscription-specific settings. The values of these pref keys must be prefixed with
          "buglesub_" to allow for runtime sanity checks -->

--- a/res/xml-v21/preferences_application.xml
+++ b/res/xml-v21/preferences_application.xml
@@ -77,33 +77,33 @@
 
     <ListPreference
         android:key="pref_key_sms_validity_period"
-        android:dialogTitle="@string/pref_title_validity_period"
+        android:dialogTitle="@string/validity_period_pref_title"
         android:persistent="true"
         android:defaultValue="@string/def_sms_validity_period_value"
         android:summary="%s"
         android:entries="@array/entries_sms_validity_period"
         android:entryValues="@array/entries_sms_validity_period_value"
-        android:title="@string/pref_title_validity_period" />
+        android:title="@string/validity_period_pref_title" />
 
     <ListPreference
         android:key="pref_key_sms_validity_period_slot1"
-        android:dialogTitle="@string/pref_title_validity_period"
+        android:dialogTitle="@string/validity_period_pref_title"
         android:persistent="true"
         android:defaultValue="@string/def_sms_validity_period_value"
         android:summary="%s"
         android:entries="@array/entries_sms_validity_period"
         android:entryValues="@array/entries_sms_validity_period_value"
-        android:title="@string/pref_title_validity_period_slot1" />
+        android:title="@string/validity_period_slot1_pref_title" />
 
     <ListPreference
         android:key="pref_key_sms_validity_period_slot2"
-        android:dialogTitle="@string/pref_title_validity_period"
+        android:dialogTitle="@string/validity_period_pref_title"
         android:persistent="true"
         android:defaultValue="@string/def_sms_validity_period_value"
         android:summary="%s"
         android:entries="@array/entries_sms_validity_period"
         android:entryValues="@array/entries_sms_validity_period_value"
-        android:title="@string/pref_title_validity_period_slot2" />
+        android:title="@string/validity_period_slot2_pref_title" />
 
 
     <SwitchPreference

--- a/res/xml-v21/preferences_per_subscription.xml
+++ b/res/xml-v21/preferences_per_subscription.xml
@@ -30,6 +30,18 @@
             android:title="@string/mms_phone_number_pref_title" />
 
         <SwitchPreference
+            android:key="delivery_reports_mms_pref_key"
+            android:title="@string/delivery_reports_mms_pref_title"
+            android:summary="@string/pref_summary_mms_delivery_reports"
+            android:defaultValue="@bool/def_mms_delivery_reports" />
+
+        <SwitchPreference
+            android:key="read_reports_mms_pref_key"
+            android:title="@string/read_reports_mms_pref_title"
+            android:summary="@string/pref_summary_mms_read_reports"
+            android:defaultValue="false" />
+
+        <SwitchPreference
             android:key="@string/auto_retrieve_mms_pref_key"
             android:title="@string/auto_retrieve_mms_pref_title"
             android:summary="@string/auto_retrieve_mms_pref_summary"
@@ -41,6 +53,38 @@
             android:title="@string/auto_retrieve_mms_when_roaming_pref_title"
             android:summary="@string/auto_retrieve_mms_when_roaming_pref_summary"
             android:defaultValue="@bool/auto_retrieve_mms_when_roaming_pref_default" />
+
+        <ListPreference android:key="expiry_mms_pref_key"
+            android:title="@string/validity_period_pref_title"
+            android:dialogTitle="@string/validity_period_pref_title"
+            android:summary="%s"
+            android:entries="@array/save_time"
+            android:entryValues="@array/save_time_values"
+            android:defaultValue="0" />
+
+        <ListPreference android:key="expiry_slot1_mms_pref_key"
+            android:title="@string/validity_period_slot1_pref_title"
+            android:dialogTitle="@string/validity_period_pref_title"
+            android:summary="%s"
+            android:entries="@array/save_time"
+            android:entryValues="@array/save_time_values"
+            android:defaultValue="0" />
+
+        <ListPreference android:key="expiry_slot2_mms_pref_key"
+            android:title="@string/validity_period_pref_title"
+            android:dialogTitle="@string/validity_period_pref_title"
+            android:summary="%s"
+            android:entries="@array/save_time"
+            android:entryValues="@array/save_time_values"
+            android:defaultValue="0" />
+
+        <ListPreference android:key="priority_mms_pref_key"
+            android:title="@string/priority_pref_title"
+            android:dialogTitle="@string/priority_pref_title"
+            android:summary="%s"
+            android:entries="@array/priority_send"
+            android:entryValues="@array/priority_send_values"
+            android:defaultValue="129" />
 
     </PreferenceCategory>
 

--- a/res/xml-v23/preferences_application.xml
+++ b/res/xml-v23/preferences_application.xml
@@ -78,33 +78,33 @@
 
     <ListPreference
         android:key="pref_key_sms_validity_period"
-        android:dialogTitle="@string/pref_title_validity_period"
+        android:dialogTitle="@string/validity_period_pref_title"
         android:persistent="true"
         android:defaultValue="@string/def_sms_validity_period_value"
         android:summary="%s"
         android:entries="@array/entries_sms_validity_period"
         android:entryValues="@array/entries_sms_validity_period_value"
-        android:title="@string/pref_title_validity_period" />
+        android:title="@string/validity_period_pref_title" />
 
     <ListPreference
         android:key="pref_key_sms_validity_period_slot1"
-        android:dialogTitle="@string/pref_title_validity_period"
+        android:dialogTitle="@string/validity_period_pref_title"
         android:persistent="true"
         android:defaultValue="@string/def_sms_validity_period_value"
         android:summary="%s"
         android:entries="@array/entries_sms_validity_period"
         android:entryValues="@array/entries_sms_validity_period_value"
-        android:title="@string/pref_title_validity_period_slot1" />
+        android:title="@string/validity_period_slot1_pref_title" />
 
     <ListPreference
         android:key="pref_key_sms_validity_period_slot2"
-        android:dialogTitle="@string/pref_title_validity_period"
+        android:dialogTitle="@string/validity_period_pref_title"
         android:persistent="true"
         android:defaultValue="@string/def_sms_validity_period_value"
         android:summary="%s"
         android:entries="@array/entries_sms_validity_period"
         android:entryValues="@array/entries_sms_validity_period_value"
-        android:title="@string/pref_title_validity_period_slot2" />
+        android:title="@string/validity_period_slot2_pref_title" />
 
 
     <SwitchPreference

--- a/res/xml/preferences_application.xml
+++ b/res/xml/preferences_application.xml
@@ -77,33 +77,33 @@
 
     <ListPreference
         android:key="pref_key_sms_validity_period"
-        android:dialogTitle="@string/pref_title_validity_period"
+        android:dialogTitle="@string/validity_period_pref_title"
         android:persistent="true"
         android:defaultValue="@string/def_sms_validity_period_value"
         android:summary="%s"
         android:entries="@array/entries_sms_validity_period"
         android:entryValues="@array/entries_sms_validity_period_value"
-        android:title="@string/pref_title_validity_period" />
+        android:title="@string/validity_period_pref_title" />
 
     <ListPreference
         android:key="pref_key_sms_validity_period_slot1"
-        android:dialogTitle="@string/pref_title_validity_period"
+        android:dialogTitle="@string/validity_period_pref_title"
         android:persistent="true"
         android:defaultValue="@string/def_sms_validity_period_value"
         android:summary="%s"
         android:entries="@array/entries_sms_validity_period"
         android:entryValues="@array/entries_sms_validity_period_value"
-        android:title="@string/pref_title_validity_period_slot1" />
+        android:title="@string/validity_period_slot1_pref_title" />
 
     <ListPreference
         android:key="pref_key_sms_validity_period_slot2"
-        android:dialogTitle="@string/pref_title_validity_period"
+        android:dialogTitle="@string/validity_period_pref_title"
         android:persistent="true"
         android:defaultValue="@string/def_sms_validity_period_value"
         android:summary="%s"
         android:entries="@array/entries_sms_validity_period"
         android:entryValues="@array/entries_sms_validity_period_value"
-        android:title="@string/pref_title_validity_period_slot2" />
+        android:title="@string/validity_period_slot2_pref_title" />
 
     <CheckBoxPreference
         android:key="pref_show_emoticons"

--- a/res/xml/preferences_per_subscription.xml
+++ b/res/xml/preferences_per_subscription.xml
@@ -30,6 +30,18 @@
             android:title="@string/mms_phone_number_pref_title" />
 
         <CheckBoxPreference
+            android:key="delivery_reports_mms_pref_key"
+            android:title="@string/delivery_reports_mms_pref_title"
+            android:summary="@string/pref_summary_mms_delivery_reports"
+            android:defaultValue="@bool/def_mms_delivery_reports" />
+
+        <CheckBoxPreference
+            android:key="read_reports_mms_pref_key"
+            android:title="@string/read_reports_mms_pref_title"
+            android:summary="@string/pref_summary_mms_read_reports"
+            android:defaultValue="false" />
+
+        <CheckBoxPreference
             android:key="@string/auto_retrieve_mms_pref_key"
             android:title="@string/auto_retrieve_mms_pref_title"
             android:summary="@string/auto_retrieve_mms_pref_summary"
@@ -42,7 +54,40 @@
             android:summary="@string/auto_retrieve_mms_when_roaming_pref_summary"
             android:defaultValue="@bool/auto_retrieve_mms_when_roaming_pref_default" />
 
-    </PreferenceCategory>
+
+        <ListPreference android:key="expiry_mms_pref_key"
+            android:title="@string/validity_period_pref_title"
+            android:dialogTitle="@string/validity_period_pref_title"
+            android:summary="%s"
+            android:entries="@array/save_time"
+            android:entryValues="@array/save_time_values"
+            android:defaultValue="0" />
+
+        <ListPreference android:key="expiry_slot1_mms_pref_key"
+            android:title="@string/validity_period_slot1_pref_title"
+            android:dialogTitle="@string/validity_period_pref_title"
+            android:summary="%s"
+            android:entries="@array/save_time"
+            android:entryValues="@array/save_time_values"
+            android:defaultValue="0" />
+
+        <ListPreference android:key="expiry_slot2_mms_pref_key"
+            android:title="@string/validity_period_slot2_pref_title"
+            android:dialogTitle="@string/validity_period_pref_title"
+            android:summary="%s"
+            android:entries="@array/save_time"
+            android:entryValues="@array/save_time_values"
+            android:defaultValue="0" />
+
+        <ListPreference android:key="priority_mms_pref_key"
+            android:title="@string/priority_pref_title"
+            android:dialogTitle="@string/priority_pref_title"
+            android:summary="%s"
+            android:entries="@array/priority_send"
+            android:entryValues="@array/priority_send_values"
+            android:defaultValue="129" />
+
+     </PreferenceCategory>
 
     <PreferenceCategory
         android:key="@string/advanced_category_pref_key"

--- a/src/com/android/messaging/sms/MmsUtils.java
+++ b/src/com/android/messaging/sms/MmsUtils.java
@@ -38,6 +38,7 @@ import android.provider.Telephony.Sms;
 import android.provider.Telephony.Threads;
 import android.telephony.SmsManager;
 import android.telephony.SmsMessage;
+import android.telephony.SubscriptionManager;
 import android.text.TextUtils;
 import android.text.util.Rfc822Token;
 import android.text.util.Rfc822Tokenizer;
@@ -97,6 +98,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
+
+import android.util.Log;
 
 /**
  * Utils for sending sms/mms messages.
@@ -2367,12 +2370,15 @@ public class MmsUtils {
     public static Uri insertSendingMmsMessage(final Context context, final List<String> recipients,
             final MessageData content, final int subId, final String subPhoneNumber,
             final long timestamp) {
+        final boolean requireDeliveryReport = isMmsDeliveryReportRequired(subId);
+        final boolean requireReadReport = isMmsDeliveryReportRequired(subId);
+        final long expiryTime = getExpiryTime(subId);
         final SendReq sendReq = createMmsSendReq(
                 context, subId, recipients.toArray(new String[recipients.size()]), content,
-                DEFAULT_DELIVERY_REPORT_MODE,
-                DEFAULT_READ_REPORT_MODE,
-                DEFAULT_EXPIRY_TIME_IN_SECONDS,
-                DEFAULT_PRIORITY,
+                requireDeliveryReport,
+                requireReadReport,
+                expiryTime,
+                getSendPriority(subId),
                 timestamp);
         Uri messageUri = null;
         if (sendReq != null) {
@@ -2505,7 +2511,9 @@ public class MmsUtils {
         // Message class
         req.setMessageClass(PduHeaders.MESSAGE_CLASS_PERSONAL_STR.getBytes());
         // Expiry
-        req.setExpiry(expiryTime);
+        if(expiryTime != -1) { // Set only if != -1 (MAX). For -1,  not calling setExpiry leads to use MAX as default.
+            req.setExpiry(expiryTime);
+        }
         // Priority
         req.setPriority(priority);
         // Delivery report
@@ -2519,13 +2527,62 @@ public class MmsUtils {
         if (!MmsConfig.get(subId).getSMSDeliveryReportsEnabled()) {
             return false;
         }
-        final Context context = Factory.get().getApplicationContext();
-        final Resources res = context.getResources();
+        final Resources res = Factory.get().getApplicationContext().getResources();
         final BuglePrefs prefs = BuglePrefs.getSubscriptionPrefs(subId);
         final String deliveryReportKey = res.getString(R.string.delivery_reports_pref_key);
         final boolean defaultValue = res.getBoolean(R.bool.delivery_reports_pref_default);
         return prefs.getBoolean(deliveryReportKey, defaultValue);
     }
+
+    private static boolean isMmsDeliveryReportRequired(final int subId) {
+        final Resources res = Factory.get().getApplicationContext().getResources();
+        final BuglePrefs prefs = BuglePrefs.getSubscriptionPrefs(subId);
+        final String mmsDeliveryReportKey = res.getString(R.string.delivery_reports_mms_pref_key);
+        final boolean defaultValue = res.getBoolean(R.bool.def_mms_delivery_reports);
+        return prefs.getBoolean(mmsDeliveryReportKey, defaultValue);
+    }
+
+    private static boolean isMmsReadReportRequired(final int subId) {
+        final Resources res = Factory.get().getApplicationContext().getResources();
+        final BuglePrefs prefs = BuglePrefs.getSubscriptionPrefs(subId);
+        final String readReportKey = res.getString(R.string.read_reports_mms_pref_key);
+        final boolean defaultValue = DEFAULT_READ_REPORT_MODE;
+        return prefs.getBoolean(readReportKey, defaultValue);
+    }
+
+    private static long getExpiryTime(final int subId) {
+        final Resources res = Factory.get().getApplicationContext().getResources();
+        final BuglePrefs prefs = BuglePrefs.getSubscriptionPrefs(subId);
+        final String expiryStr = res.getString(R.string.expiry_mms_pref_key);
+        final String expiryStr1 = res.getString(R.string.expiry_slot1_mms_pref_key);
+        final String expiryStr2 = res.getString(R.string.expiry_slot2_mms_pref_key);
+        final int mPhoneId = SubscriptionManager.getPhoneId(subId);
+
+        // Expiry.
+        long expiryTime = 0;
+
+        if (PhoneUtils.getDefault().isMultiSimEnabledMms()) {
+            expiryTime = Long.parseLong(
+                    prefs.getString((mPhoneId == 0) ?
+                            expiryStr1:
+                            expiryStr2, "0"));
+        } else {
+            expiryTime = Long.parseLong(
+                    prefs.getString(expiryStr, "0"));
+        }
+
+        return expiryTime != 0 ? expiryTime : DEFAULT_EXPIRY_TIME_IN_SECONDS;
+    }
+
+    private static int getSendPriority(final int subId){
+        final Resources res = Factory.get().getApplicationContext().getResources();
+        final BuglePrefs prefs = BuglePrefs.getSubscriptionPrefs(subId);
+        final String sendPriorityMmsKey = res.getString(R.string.priority_mms_pref_key);
+        String priority = prefs.getString(sendPriorityMmsKey, Integer.toString(DEFAULT_PRIORITY));
+        return Integer.parseInt(priority);
+    }
+
+
 
     public static int sendSmsMessage(final String recipient, final String messageText,
             final Uri requestUri, final int subId,

--- a/src/com/android/messaging/ui/appsettings/PerSubscriptionSettingsActivity.java
+++ b/src/com/android/messaging/ui/appsettings/PerSubscriptionSettingsActivity.java
@@ -24,6 +24,7 @@ import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.preference.Preference;
+import android.preference.ListPreference;
 import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
@@ -80,6 +81,10 @@ public class PerSubscriptionSettingsActivity extends BugleActionBarActivity {
             implements OnSharedPreferenceChangeListener {
         private PhoneNumberPreference mPhoneNumberPreference;
         private Preference mGroupMmsPreference;
+        private ListPreference mMmsExpiryPref;
+        private ListPreference mMmsExpiryCard1Pref;
+        private ListPreference mMmsExpiryCard2Pref;
+
         private String mGroupMmsPrefKey;
         private String mPhoneNumberKey;
         private int mSubId;
@@ -184,6 +189,20 @@ public class PerSubscriptionSettingsActivity extends BugleActionBarActivity {
                 final Preference deliveryReportsPreference =
                         findPreference(getString(R.string.delivery_reports_pref_key));
                 deliveryReportsPreference.setEnabled(false);
+            }
+
+            mMmsExpiryPref = (ListPreference)
+                    findPreference(getString(R.string.expiry_mms_pref_key));
+            mMmsExpiryCard1Pref = (ListPreference)
+                    findPreference(getString(R.string.expiry_slot1_mms_pref_key));
+            mMmsExpiryCard2Pref = (ListPreference)
+                    findPreference(getString(R.string.expiry_slot2_mms_pref_key));
+
+            if (PhoneUtils.getDefault().isMultiSimEnabledMms()) {
+                mmsCategory.removePreference(mMmsExpiryPref);
+            } else {
+                mmsCategory.removePreference(mMmsExpiryCard1Pref);
+                mmsCategory.removePreference(mMmsExpiryCard2Pref);
             }
         }
 


### PR DESCRIPTION
Sending Report

New preference field for mms are added in Messaging advanced settings
ported from CyanogenMod 12.0 Messaging application to CyanogenMod 13.0.
New preference field for MMS Send Priority are added in Messaging advanced
settings and changed Naming Conventions and chmod changed to 644

Bug: PAELLA-187,PAELLA-188,PAELLA-189
Change-Id: I7d9461bb1f967003733c669cf08edc480c2cc5c5