### PR TITLE
Messaging: Fix broken and untested features.

### DIFF
--- a/res/values/cm_arrays.xml
+++ b/res/values/cm_arrays.xml
@@ -63,7 +63,7 @@
         <item>604800</item>
     </string-array>
 
-    <string-array name="priority_send_values" >
+    <string-array name="priority_send_values" translatable="false" >
         <item>128</item>    <!-- PRIORITY_LOW  -->
         <item>129</item>    <!--PRIORITY_NORMAL -->
         <item>130</item>    <!-- PRIORITY_HIGH  -->

--- a/res/values/cm_constants.xml
+++ b/res/values/cm_constants.xml
@@ -26,4 +26,14 @@
     <!-- Preference keys for user-visible settings -->
     <!-- Application-wide settings -->
     <bool name="show_emoticons_pref_default" translatable="false">true</bool>
+
+    <!-- Subscription-specific settings. The values of these pref keys must be prefixed with
+     "buglesub_" to allow for runtime sanity checks -->
+    <string name="expiry_mms_pref_key" translatable="false">buglesub_expiry_mms_pref_key</string>
+    <string name="expiry_slot1_mms_pref_key" translatable="false">buglesub_expiry_slot1_mms_pref_key</string>
+    <string name="expiry_slot2_mms_pref_key" translatable="false">buglesub_expiry_slot2_mms_pref_key</string>
+    <string name="delivery_reports_mms_pref_key" translatable="false">buglesub_delivery_reports_mms_pref_key</string>
+    <bool name="def_mms_delivery_reports">false</bool>
+    <string name="read_reports_mms_pref_key" translatable="false">buglesub_read_reports_mms_pref_key</string>
+    <string name="priority_mms_pref_key" translatable="false">buglesub_priority_mms_pref_key</string>
 </resources>

--- a/res/values/constants.xml
+++ b/res/values/constants.xml
@@ -26,12 +26,6 @@
     <string name="pref_key_sms_validity_period" translatable="false">pref_key_sms_validity_period</string>
     <string name="pref_key_sms_validity_period_slot1" translatable="false">pref_key_sms_validity_period_slot1</string>
     <string name="pref_key_sms_validity_period_slot2" translatable="false">pref_key_sms_validity_period_slot2</string>
-    <string name="expiry_mms_pref_key" translatable="false">expiry_mms_pref_key</string>
-    <string name="expiry_slot1_mms_pref_key" translatable="false">expiry_slot1_mms_pref_key</string>
-    <string name="expiry_slot2_mms_pref_key" translatable="false">expiry_slot2_mms_pref_key</string>
-    <string name="delivery_reports_mms_pref_key" translatable="false">delivery_reports_mms_pref_key</string>
-    <string name="read_reports_mms_pref_key" translatable="false">read_reports_mms_pref_key</string>
-    <string name="priority_mms_pref_key" translatable="false">priority_mms_pref_key</string>
     <bool name="notifications_enabled_pref_default" translatable="false">true</bool>
     <string name="notification_sound_pref_key" translatable="false">notification_sound</string>
     <string name="notification_vibration_pref_key" translatable="false">notification_vibration</string>
@@ -49,9 +43,6 @@
 
     <!-- default sms validity period -->
     <string name="def_sms_validity_period_value" translatable="false">-1</string>
-
-    <!-- mms delivery reports enabled.default is true to on,false to off -->
-    <bool name="def_mms_delivery_reports">false</bool>
 
     <!-- Subscription-specific settings. The values of these pref keys must be prefixed with
          "buglesub_" to allow for runtime sanity checks -->


### PR DESCRIPTION
  Since the features for validity, delivery, read
  report and sending report are all per subscription,
  they need to abide by the runtime sanity checks provided
  by the BuglePrefs implementation which asserts that any
  such preferences will hava key that is prefixed with
  "buglesub_"

Change-Id: Iba026257c6514e4ab4e9640d1615d4da4a0cfd62
TICKET: PAELLA-187,PAELLA-188,PAELLA-189