### PR TITLE
Fixed storage permission issue for attachments

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -146,4 +146,19 @@
     <string name="operation_to_card_memory">Copy message to SIM card</string>
     <string name="slot1">SIM 1</string>
     <string name="slot2">SIM 2</string>
+
+    <!-- Audio Library Tab for MMS attachments -->
+    <string name="mediapicker_galleryChooserDescription_cm">Choose images or videos from this
+        device</string>
+    <string name="mediapicker_audioListChooserDescription">Choose audio files from this
+        device</string>
+    <string name="mediapicker_gallery_image_item_attachment_too_large">Can\'t attach video.
+        Max message size exceeded.</string>
+    <string name="mediapicker_audio_list_title">Choose audio</string>
+    <string name="mediapicker_audio_list_item_selected_content_description">The audio is selected
+        .</string>
+    <string name="mediapicker_audio_list_item_unselected_content_description">The audio is
+        unselected.</string>
+    <string name="mediapicker_audio_list_title_selection"><xliff:g id="count">%d</xliff:g> selected
+    </string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -53,7 +53,6 @@
     <string name="mediapicker_cameraChooserDescription">Capture pictures or video</string>
     <string name="mediapicker_galleryChooserDescription">Choose images or videos from this
         device</string>
-    <string name="mediapicker_audioListChooserDescription">Choose audios from this device</string>
     <string name="mediapicker_audioChooserDescription">Record audio</string>
     <string name="mediapicker_gallery_title">Choose photo</string>
     <string name="mediapicker_gallery_item_selected_content_description">The media is selected.</string>
@@ -62,20 +61,8 @@
     <!-- example: "image January 17 2015 1 59 pm" -->
     <string name="mediapicker_gallery_image_item_description">image <xliff:g id="date">%1$tB %1$te %1$tY %1$tl %1$tM %1$tp</xliff:g></string>
     <string name="mediapicker_gallery_image_item_description_no_date">image</string>
-    <string name="mediapicker_gallery_image_item_attachment_too_large">Can\'t attach video.
-        Max message size exceeded.</string>
-    <string name="mediapicker_audio_list_title">Choose audio</string>
-    <string name="mediapicker_audio_list_item_selected_content_description">The audio is selected
-        .</string>
-    <string name="mediapicker_audio_list_item_unselected_content_description">The audio is
-        unselected
-        .</string>
-    <string name="mediapicker_audio_list_title_selection"><xliff:g id="count">%d</xliff:g> selected
-    </string>
     <string name="mediapicker_audio_title">Record audio</string>
-
     <string name="action_share">Share</string>
-
     <string name="posted_just_now">"Just now"</string>
     <string name="posted_now">"Now"</string>
 

--- a/src/com/android/messaging/ui/mediapicker/AudioListChooser.java
+++ b/src/com/android/messaging/ui/mediapicker/AudioListChooser.java
@@ -174,6 +174,9 @@ class AudioListChooser extends MediaChooser implements
             // Work around a bug in MediaStore where cursors querying the Files provider don't get
             // updated for changes to Images.Media or Video.Media.
             startMediaPickerDataLoader();
+            updateForPermissionState(true);
+        } else {
+            updateForPermissionState(false);
         }
     }
 
@@ -183,7 +186,7 @@ class AudioListChooser extends MediaChooser implements
         if (selected && !OsUtil.hasStoragePermission()) {
             mMediaPicker.requestPermissions(
                     new String[] { Manifest.permission.READ_EXTERNAL_STORAGE },
-                    MediaPicker.GALLERY_PERMISSION_REQUEST_CODE);
+                    MediaPicker.AUDIO_LIBRARY_PERMISSION_REQUEST_CODE);
         }
     }
 
@@ -195,7 +198,7 @@ class AudioListChooser extends MediaChooser implements
     @Override
     protected void onRequestPermissionsResult(
             final int requestCode, final String permissions[], final int[] grantResults) {
-        if (requestCode == MediaPicker.GALLERY_PERMISSION_REQUEST_CODE) {
+        if (requestCode == MediaPicker.AUDIO_LIBRARY_PERMISSION_REQUEST_CODE) {
             final boolean permissionGranted = grantResults[0] == PackageManager.PERMISSION_GRANTED;
             if (permissionGranted) {
                 startMediaPickerDataLoader();

--- a/src/com/android/messaging/ui/mediapicker/GalleryMediaChooser.java
+++ b/src/com/android/messaging/ui/mediapicker/GalleryMediaChooser.java
@@ -24,7 +24,6 @@ import android.database.MergeCursor;
 import android.provider.Telephony;
 import android.support.v7.app.ActionBar;
 import android.support.v7.mms.CarrierConfigValuesLoader;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -196,6 +195,9 @@ class GalleryMediaChooser extends MediaChooser implements
             // Work around a bug in MediaStore where cursors querying the Files provider don't get
             // updated for changes to Images.Media or Video.Media.
             startMediaPickerDataLoader();
+            updateForPermissionState(true);
+        } else {
+            updateForPermissionState(false);
         }
     }
 

--- a/src/com/android/messaging/ui/mediapicker/MediaPicker.java
+++ b/src/com/android/messaging/ui/mediapicker/MediaPicker.java
@@ -726,6 +726,7 @@ public class MediaPicker extends Fragment implements DraftMessageSubscriptionDat
     protected static final int LOCATION_PERMISSION_REQUEST_CODE = 2;
     protected static final int RECORD_AUDIO_PERMISSION_REQUEST_CODE = 3;
     protected static final int GALLERY_PERMISSION_REQUEST_CODE = 4;
+    protected static final int AUDIO_LIBRARY_PERMISSION_REQUEST_CODE = 5;
 
     @Override
     public void onRequestPermissionsResult(


### PR DESCRIPTION
Moved some audio library tab related string to cm_strings.xml

When Storage Permissions were being requested and granted, they
were applied to either the Gallery (image & video) or Audio tab.
This patch makes sure that the permissions are propagated to both.

Change-Id: I75cc9c4cdf05062a0b37a842fca9ebcb6f404a40
TicketId: Kipper-587
TicketId: Crackling-937
TicketId: Feij-143
TicketId: Porridge-64