### PR TITLE
Messaging: fix cursor not close explicitly

### DIFF
--- a/src/com/android/messaging/sms/MmsUtils.java
+++ b/src/com/android/messaging/sms/MmsUtils.java
@@ -1448,10 +1448,10 @@ public class MmsUtils {
         final Cursor c = SqliteWrapper.query(context, context.getContentResolver(),
                 Mms.Inbox.CONTENT_URI, projection, selection,
                 new String[]{String.valueOf(threadId)}, null);
+        if (c == null) {
+            return;
+        }
         try {
-            if (c == null || c.getCount() == 0) {
-                return;
-            }
             while (c.moveToNext()) {
                 Uri uri = ContentUris.withAppendedId(Mms.CONTENT_URI, c.getLong(0));
                 String from = MmsUtils.getMmsSender(recipients, uri.toString());
@@ -1460,9 +1460,7 @@ public class MmsUtils {
                         self.getNormalizedDestination(), c.getString(1), status);
             }
         } finally {
-            if (c != null) {
-                c.close();
-            }
+            c.close();
         }
 
     }


### PR DESCRIPTION
Cursor always need to be close after query.

FEIJ-1585

Change-Id: Ie523c89b6271a28d3d2d8a08232387c1bd609880