### PR TITLE
Clear avatar media cache on theme change

### DIFF
--- a/src/com/android/messaging/BugleApplication.java
+++ b/src/com/android/messaging/BugleApplication.java
@@ -21,6 +21,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Handler;
@@ -30,6 +31,9 @@ import android.support.v7.mms.MmsManager;
 import android.telephony.CarrierConfigManager;
 
 import com.android.messaging.datamodel.DataModel;
+import com.android.messaging.datamodel.media.BugleMediaCacheManager;
+import com.android.messaging.datamodel.media.MediaCache;
+import com.android.messaging.datamodel.media.MediaCacheManager;
 import com.android.messaging.receiver.SmsReceiver;
 import com.android.messaging.sms.ApnDatabase;
 import com.android.messaging.sms.BugleApnSettingsLoader;
@@ -66,6 +70,8 @@ public class BugleApplication extends Application implements UncaughtExceptionHa
     // Lookup provider members
     private static LookupProviderManager sLookupProviderManager;
 
+    private Configuration mCurrentConfig;
+
     @VisibleForTesting
     protected static void setTestsRunning() {
         sRunningTests = true;
@@ -99,6 +105,8 @@ public class BugleApplication extends Application implements UncaughtExceptionHa
         BlacklistSync blacklistSync = new BlacklistSync(getApplicationContext());
         blacklistSync.execute();
 
+        mCurrentConfig = new Configuration(getResources().getConfiguration());
+
 
         sSystemUncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
         Thread.setDefaultUncaughtExceptionHandler(this);
@@ -115,6 +123,14 @@ public class BugleApplication extends Application implements UncaughtExceptionHa
         // Update conversation drawables when changing writing systems
         // (Right-To-Left / Left-To-Right)
         ConversationDrawables.get().updateDrawables();
+
+        // Clear avatar image cache on theme change
+        int changed = mCurrentConfig.updateFrom(newConfig);
+        if ((changed & ActivityInfo.CONFIG_THEME_RESOURCE) != 0) {
+            MediaCache<?> avatarCache = MediaCacheManager.get()
+                    .getOrCreateMediaCacheById(BugleMediaCacheManager.AVATAR_IMAGE_CACHE);
+            avatarCache.destroy();
+        }
     }
 
     // Called by the "real" factory from FactoryImpl.register() (i.e. not run in tests)


### PR DESCRIPTION
Default avatars retained the previou;sly applied theme's colors
due to the avatar images being cached.  This patch checks if a
theme change has occurred and if so destroys the avatar media cache
so that it can be rebuilt with the newly applied theme's colors.

Change-Id: Iab3d6e0171a949235da643fc80bf54d9375e42fb
TICKET: CYNGNOS-3118